### PR TITLE
add useDomainView and modify SI viewlet to make use of it, WIP

### DIFF
--- a/src/collective/siteimprove/browser/configure.zcml
+++ b/src/collective/siteimprove/browser/configure.zcml
@@ -28,6 +28,14 @@
       layer="collective.siteimprove.interfaces.ICollectiveSiteimproveLayer"
       />
 
+  <browser:page
+      name="si-use-domain"
+      for="*"
+      class=".utils.UseDomainView"
+      permission="collective.siteimprove.UseSiteimprove"
+      layer="collective.siteimprove.interfaces.ICollectiveSiteimproveLayer"
+      />
+
   <browser:viewlet
       name="siteimprove-head"
       for="*"

--- a/src/collective/siteimprove/browser/siteimprove-head.pt
+++ b/src/collective/siteimprove/browser/siteimprove-head.pt
@@ -1,11 +1,11 @@
-<tal:token condition="view/token" tal:define="visible context/@@si-anon-can-view">
+<tal:token condition="view/token" tal:define="use_domain context/@@si-use-domain">
     <script src="https://cdn.siteimprove.net/cms/overlay.js" async></script>
     <tal:tag replace="structure string:<script>"/>
         var _siteimprove_token = '${view/token}';
         document.addEventListener("DOMContentLoaded", function(event) {
             require(['jquery', 'siteimprove'], function ($, siteimprove) {
-                <tal:domain condition="not:visible">siteimprove.domain();</tal:domain>
-                <tal:domain condition="visible">siteimprove.input();</tal:domain>
+                <tal:not_domain condition="not:use_domain">siteimprove.input();</tal:not_domain>
+                <tal:domain condition="use_domain">siteimprove.domain();</tal:domain>
                 <tal:recheck condition="view/recheck|nothing">siteimprove.recheck();</tal:recheck>
                 $('#plone-contentmenu-actions-siteimprove').on('click', function () {
                     siteimprove.recheck();

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -4,6 +4,8 @@ from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityInfo import ModuleSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
 from zope.component import getMultiAdapter
+from Products.CMFCore.interfaces import ISiteRoot
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five.browser import BrowserView
 
 
@@ -28,6 +30,8 @@ class UseDomainView(BrowserView):
 
         # XXX This is not correct -- fix method to calculate when we are at root of site
         if context_path == site_path:
+            use_domain == True
+        if IPloneSiteRoot.providedBy(self.context):
             use_domain == True
 
         return use_domain

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -19,12 +19,8 @@ class UseDomainView(BrowserView):
        false implies that input function will be used instead"""
 
     def __call__(self):
-        use_domain = False # use input function by default
-
         # figure out if domain function should be used instead
         context_state = getMultiAdapter((self.context, self.request), name=u'plone_context_state')
         if context_state is not None:
-            if context_state.is_portal_root():
-                use_domain = True
-
-        return use_domain
+            return context_state.is_portal_root() # use domain function if true
+        return False # use input function

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -3,6 +3,7 @@ from AccessControl.Role import gather_permissions
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityInfo import ModuleSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
+from zope.component import getMultiAdapter
 from Products.Five.browser import BrowserView
 
 
@@ -12,3 +13,21 @@ class AnonCanView(BrowserView):
     def __call__(self):
         """Can we see this"""
         return 'Anonymous' in rolesForPermissionOn('View', self.context)
+class UseDomainView(BrowserView):
+    """Returns true if the domain function is to be used in the siteimprove js header
+       false implies that input function will be used instead"""
+
+    def __call__(self):
+        use_domain = False # use input function by default
+
+        # figure out if domain function should be used instead
+        portal_state = getMultiAdapter((self.context, self.request), name=u'plone_portal_state')
+        site = portal_state.portal() #site root
+        site_path = site.getPhysicalPath();
+        context_path = self.context.getPhysicalPath()
+
+        # XXX This is not correct -- fix method to calculate when we are at root of site
+        if context_path == site_path:
+            use_domain == True
+
+        return use_domain

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -4,7 +4,6 @@ from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityInfo import ModuleSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
 from zope.component import getMultiAdapter
-from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five.browser import BrowserView
 
@@ -23,15 +22,8 @@ class UseDomainView(BrowserView):
         use_domain = False # use input function by default
 
         # figure out if domain function should be used instead
-        portal_state = getMultiAdapter((self.context, self.request), name=u'plone_portal_state')
-        site = portal_state.portal() #site root
-        site_path = site.getPhysicalPath();
-        context_path = self.context.getPhysicalPath()
-
-        # XXX This is not correct -- fix method to calculate when we are at root of site
-        if context_path == site_path:
-            use_domain == True
-        if IPloneSiteRoot.providedBy(self.context):
+        context_state = getMultiAdapter((self.context, self.request), name=u'plone_context_state')
+        if context_state.is_portal_root():
             use_domain == True
 
         return use_domain

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -23,7 +23,8 @@ class UseDomainView(BrowserView):
 
         # figure out if domain function should be used instead
         context_state = getMultiAdapter((self.context, self.request), name=u'plone_context_state')
-        if context_state.is_portal_root():
-            use_domain == True
+        if context_state is not None:
+            if context_state.is_portal_root():
+                use_domain = True
 
         return use_domain

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -3,7 +3,7 @@ from AccessControl.Role import gather_permissions
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.SecurityInfo import ModuleSecurityInfo
 from AccessControl.SecurityManagement import getSecurityManager
-from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from Products.Five.browser import BrowserView
 
@@ -20,7 +20,7 @@ class UseDomainView(BrowserView):
 
     def __call__(self):
         # figure out if domain or input function should be used
-        context_state = getMultiAdapter((self.context, self.request), name=u'plone_context_state')
+        context_state = queryMultiAdapter((self.context, self.request), name=u'plone_context_state')
         if context_state is not None:
             return context_state.is_portal_root() # use domain function if true
         return False # use input function

--- a/src/collective/siteimprove/browser/utils.py
+++ b/src/collective/siteimprove/browser/utils.py
@@ -19,7 +19,7 @@ class UseDomainView(BrowserView):
        false implies that input function will be used instead"""
 
     def __call__(self):
-        # figure out if domain function should be used instead
+        # figure out if domain or input function should be used
         context_state = getMultiAdapter((self.context, self.request), name=u'plone_context_state')
         if context_state is not None:
             return context_state.is_portal_root() # use domain function if true


### PR DESCRIPTION
(copying here from previous PR for convenience)
@alecm
ok so you propose we call input on both published and unpublished pages?
and then use domain on the home page and according to some heuristic on other selected pages?

If this is the case, this is what I'm attempting to implement in this branch and PR.

Right now (on master) its:

                <tal:domain condition="not:visible">siteimprove.domain();</tal:domain>
                <tal:domain condition="visible">siteimprove.input();</tal:domain>
So if a page is published (visible to anonymous users), we use input and domain for non-published pages.