### PR TITLE
Added link to CMS Plugin documentation page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,9 @@ API that is required to provide these features. The only thing Plone
 admins need to do is install the add-on and configure a Siteimprove
 token.
 
+For more information on using Siteimprove within Plone, 
+see `How to navigate the Siteimprove CMS Plugin
+<https://support.siteimprove.com/hc/en-gb/articles/115000075451-How-to-navigate-the-Siteimprove-CMS-Plugin>`_.
 
 Features
 --------


### PR DESCRIPTION
@witekdev @alecpm I discovered Siteimprove has a helpful page about how their plugin works, so I added it to the README.

@alecpm could you please review, merge, and release once again. Sorry for the trouble and no rush.